### PR TITLE
mode must be a string

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -87,7 +87,7 @@ DAEMON_OPTS=""
                 content => $default_content,
                 owner   => 0,
                 group   => 0,
-                mode    => 0644,
+                mode    => '0644',
             }
         }
 


### PR DESCRIPTION
Puppet agent complains that the mode must be string and not a fixnum.