### PR TITLE
correcting 2 syntax errors

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,7 +63,7 @@ class puppet_run::install (
                 }
 
                 exec {'load_puppet_run':
-                    command     => '/bin/launchctl -w load /Library/LaunchDaemons/com.grahamgilbert.puppet_run.plist',
+                    command     => '/bin/launchctl load -w /Library/LaunchDaemons/com.grahamgilbert.puppet_run.plist',
                     refreshonly => true,
                 }
             }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,14 +2,14 @@ class puppet_run::service (
     $server_name = $puppet_run::server_name
 ){
     case $operatingsystem {
-        Darwin:{
+        'Darwin':{
             service { 'com.grahamgilbert.puppet_run':
                 ensure  => 'running',
                 enable  => 'true',
             }
         }
 
-        Ubuntu:{
+        'Ubuntu':{
             service {'puppet':
                 ensure  => running,
             }


### PR DESCRIPTION
first error is with "launchctl".
The second error is with bare words. The Puppet documentation says "To be treated as a string, a bare word must: Begin with a lower case letter, ...". So Darwin and Ubuntu need to be quoted.

When testing with Puppetserver 2.7.2, I got this error:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Resource type not found: Darwin at /etc/puppetlabs/code/environments/production/modules/puppet_run/manifests/service.pp:5:9 on node host1